### PR TITLE
adding support to parse extern method definitions

### DIFF
--- a/src/parsetree/method.rs
+++ b/src/parsetree/method.rs
@@ -51,6 +51,8 @@ pub struct VelosiParseTreeMethod {
     pub is_abstract: bool,
     /// whether this is a method to be synthesized
     pub is_synth: bool,
+    /// whether the method is externally defined
+    pub is_extern: bool,
     /// the unit parameters
     pub params: Vec<VelosiParseTreeParam>,
     /// the name of the derrived unit
@@ -81,6 +83,10 @@ impl Display for VelosiParseTreeMethod {
                 }
             }
             writeln!(f, "]")?;
+        }
+
+        if self.is_extern {
+            write!(f, "extern ")?;
         }
 
         if self.is_abstract {

--- a/tests/vrs/methods/methods_02_synth_abstract.vrs
+++ b/tests/vrs/methods/methods_02_synth_abstract.vrs
@@ -24,12 +24,34 @@ segment MyUnit {
     }
 
 
+    // extern method
+    extern fn foo() -> bool
+        requires true;
+
+
+    extern fn foo() -> bool
+        requires true;
+    {
+        true
+    }
+
     // synth + abstract method
     abstract synth fn foo() -> bool
         requires true;
 
     // synth + abstract method
     abstract synth fn foo() -> bool
+        requires true;
+    {
+        true
+    }
+
+    // extern + synth + abstract method
+    extern abstract synth fn foo() -> bool
+        requires true;
+
+    // extern + synth + abstract method
+    extern abstract synth fn foo() -> bool
         requires true;
     {
         true

--- a/tests/vrs/methods/methods_02_synth_abstract_expected.txt
+++ b/tests/vrs/methods/methods_02_synth_abstract_expected.txt
@@ -19,10 +19,28 @@ segment MyUnit {
     true
   }
 
+  extern fn foo() -> bool
+    requires true
+
+  extern fn foo() -> bool
+    requires true
+  {
+    true
+  }
+
   abstract synth fn foo() -> bool
     requires true
 
   abstract synth fn foo() -> bool
+    requires true
+  {
+    true
+  }
+
+  extern abstract synth fn foo() -> bool
+    requires true
+
+  extern abstract synth fn foo() -> bool
     requires true
   {
     true


### PR DESCRIPTION
This PR brings the ability to declare a method as `extern`. The parser now allows parsing of methods as:
```
extern abstract synth fn foo()
```
The order must be followed. 