### PR TITLE
parser: support more range expressions

### DIFF
--- a/src/parser/map.rs
+++ b/src/parser/map.rs
@@ -320,8 +320,7 @@ fn test_map_dest_fail() {
 #[test]
 fn test_map_src_ok() {
     test_parse_and_check_ok!("0..0x1000 =>", map_src);
-    // TODO: should have support for this...
-    test_parse_and_check_fail!("i * 0x1000..(i+1) * 0x1000 =>", map_src);
+    test_parse_and_check_ok!("i * 0x1000..(i + 1) * 0x1000 =>", map_src);
 }
 
 #[test]
@@ -343,8 +342,7 @@ fn test_map_element_ok() {
     test_parse_and_compare_ok!("0..4096 => UnitA() @ 4096", map_element);
     test_parse_and_compare_ok!("0..4096 => UnitA() @ 4096 + (i * 4096)", map_element);
 
-    // TODO: should have support for this...
-    test_parse_and_check_fail!("i * 4096..(i+1) * 4096 => UnitA()", map_element);
+    test_parse_and_compare_ok!("i * 4096..(i + 1) * 4096 => UnitA()", map_element);
 }
 
 #[test]

--- a/src/parsetree/expr.rs
+++ b/src/parsetree/expr.rs
@@ -543,22 +543,38 @@ impl Debug for VelosiParseTreeIfElseExpr {
 #[derive(PartialEq, Eq, Clone)]
 pub struct VelosiParseTreeRangeExpr {
     /// start of the range (including)
-    pub start: u64,
+    pub start: Box<VelosiParseTreeExpr>,
     /// end value of the range (not including)
-    pub end: u64,
+    pub end: Box<VelosiParseTreeExpr>,
     /// location of the range expression in the source tree
     pub loc: VelosiTokenStream,
 }
 
 impl VelosiParseTreeRangeExpr {
     /// constructs a new range expression with default location
-    pub fn with_loc(start: u64, end: u64, loc: VelosiTokenStream) -> Self {
-        Self { start, end, loc }
+    pub fn with_loc(
+        start: VelosiParseTreeExpr,
+        end: VelosiParseTreeExpr,
+        loc: VelosiTokenStream,
+    ) -> Self {
+        Self {
+            start: Box::new(start),
+            end: Box::new(end),
+            loc,
+        }
     }
 
     /// constructs a new range expression with default location
-    pub fn new(start: u64, end: u64) -> Self {
+    pub fn new(start: VelosiParseTreeExpr, end: VelosiParseTreeExpr) -> Self {
         Self::with_loc(start, end, VelosiTokenStream::default())
+    }
+
+    pub fn new_fixed(start: u64, end: u64) -> Self {
+        Self::with_loc(
+            VelosiParseTreeExpr::NumLiteral(VelosiParseTreeNumLiteral::new(start)),
+            VelosiParseTreeExpr::NumLiteral(VelosiParseTreeNumLiteral::new(end)),
+            VelosiTokenStream::default(),
+        )
     }
 }
 


### PR DESCRIPTION
Previously, the parser required integer literals as the bounds for range expressions. We now expand that to support normal expressions there. Note the parser will parse any expression.