### PR TITLE
toolchain: bumping rust version to 1.75

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.73.0"
+channel = "1.75.0"
 components = [ "rustfmt", "rustc", "rust-std", "cargo", "clippy", "rust-analyzer", "rls", "rust-docs" ]
 profile = "default"


### PR DESCRIPTION
This increases the rust toolchain version to 1.75. 