### PR TITLE
adding support do declare 'instr' interface fields

### DIFF
--- a/lib/velosilexer/src/tokens.rs
+++ b/lib/velosilexer/src/tokens.rs
@@ -82,8 +82,10 @@ pub enum VelosiKeyword {
     Mem,
     /// field that is a register
     Reg,
-    /// field that is a memory-mapped regsiter
+    /// field that is a memory-mapped registers
     Mmio,
+    /// a special instruction that is being executed
+    Instr,
 
     //
     // interface descriptions
@@ -108,7 +110,7 @@ pub enum VelosiKeyword {
     //
     // control flow and expressions
     //
-    /// conditional statemt
+    /// conditional statement
     If,
     /// conditional else branch
     Else,
@@ -189,6 +191,7 @@ impl VelosiKeyword {
             VelosiKeyword::Mem => "mem",
             VelosiKeyword::Reg => "reg",
             VelosiKeyword::Mmio => "mmio",
+            VelosiKeyword::Instr => "instr",
 
             // interface descriptions
             VelosiKeyword::ReadActions => "ReadActions",
@@ -256,6 +259,7 @@ impl<'a> TryFrom<&'a str> for VelosiKeyword {
             "reg" => Ok(VelosiKeyword::Reg),
             "mem" => Ok(VelosiKeyword::Mem),
             "mmio" => Ok(VelosiKeyword::Mmio),
+            "instr" => Ok(VelosiKeyword::Instr),
             //  interface descriptions
             "ReadActions" => Ok(VelosiKeyword::ReadActions),
             "WriteActions" => Ok(VelosiKeyword::WriteActions),
@@ -702,6 +706,8 @@ fn test_enum_str() {
     assert_eq!(VelosiKeyword::Reg.as_str(), "reg");
     assert_eq!("mmio".try_into(), Ok(VelosiKeyword::Mmio));
     assert_eq!(VelosiKeyword::Mmio.as_str(), "mmio");
+    assert_eq!("instr".try_into(), Ok(VelosiKeyword::Instr));
+    assert_eq!(VelosiKeyword::Instr.as_str(), "instr");
 
     assert_eq!("ReadActions".try_into(), Ok(VelosiKeyword::ReadActions));
     assert_eq!(VelosiKeyword::ReadActions.as_str(), "ReadActions");

--- a/src/parser/terminals.rs
+++ b/src/parser/terminals.rs
@@ -238,6 +238,7 @@ keywordparser!(pub kw_mapdef, VelosiKeyword::Map);
 keywordparser!(pub kw_mem, VelosiKeyword::Mem);
 keywordparser!(pub kw_reg, VelosiKeyword::Reg);
 keywordparser!(pub kw_mmio, VelosiKeyword::Mmio);
+keywordparser!(pub kw_instr, VelosiKeyword::Instr);
 
 keywordparser!(pub kw_readaction, VelosiKeyword::ReadActions);
 keywordparser!(pub kw_writeaction, VelosiKeyword::WriteActions);

--- a/src/parsetree/interface.rs
+++ b/src/parsetree/interface.rs
@@ -486,6 +486,69 @@ impl Debug for VelosiParseTreeInterfaceFieldRegister {
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+// Interface Instruction Field
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Represents a instruction interface field
+#[derive(PartialEq, Eq, Clone)]
+pub struct VelosiParseTreeInterfaceFieldInstruction {
+    /// the identifer of the field
+    pub name: VelosiParseTreeIdentifier,
+    /// nodes of the field
+    pub nodes: Vec<VelosiParseTreeInterfaceFieldNode>,
+    /// location of the field in the source file
+    pub loc: VelosiTokenStream,
+}
+
+impl VelosiParseTreeInterfaceFieldInstruction {
+    /// constructs a new register interface field
+    pub fn with_loc(
+        name: VelosiParseTreeIdentifier,
+        nodes: Vec<VelosiParseTreeInterfaceFieldNode>,
+        loc: VelosiTokenStream,
+    ) -> Self {
+        Self { name, nodes, loc }
+    }
+
+    /// constructs a new register interface field with default location
+    pub fn new(
+        name: VelosiParseTreeIdentifier,
+        nodes: Vec<VelosiParseTreeInterfaceFieldNode>,
+    ) -> Self {
+        Self::with_loc(name, nodes, VelosiTokenStream::default())
+    }
+}
+
+/// Implementation of [Display] for [VelosiParseTreeInterfaceFieldInstruction]
+impl Display for VelosiParseTreeInterfaceFieldInstruction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "instr {}", self.name)?;
+        if !self.nodes.is_empty() {
+            writeln!(f, " {{")?;
+            for node in &self.nodes {
+                let formatted = format!("{node}");
+                for (i, l) in formatted.lines().enumerate() {
+                    if i > 0 {
+                        writeln!(f)?;
+                    }
+                    write!(f, "  {l}")?;
+                }
+                writeln!(f, ",")?;
+            }
+            write!(f, "}}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Implementation of [Debug] for [VelosiParseTreeInterfaceFieldInstruction]
+impl Debug for VelosiParseTreeInterfaceFieldInstruction {
+    fn fmt(&self, format: &mut Formatter) -> FmtResult {
+        Display::fmt(&self, format)
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 // Interface Fields
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -495,6 +558,7 @@ pub enum VelosiParseTreeInterfaceField {
     Memory(VelosiParseTreeInterfaceFieldMemory),
     Mmio(VelosiParseTreeInterfaceFieldMmio),
     Register(VelosiParseTreeInterfaceFieldRegister),
+    Instruction(VelosiParseTreeInterfaceFieldInstruction),
 }
 
 /// Implementation of [Display] for [VelosiParseTreeInterfaceField]
@@ -505,6 +569,7 @@ impl Display for VelosiParseTreeInterfaceField {
             Memory(field) => Display::fmt(field, f),
             Mmio(field) => Display::fmt(field, f),
             Register(field) => Display::fmt(field, f),
+            Instruction(field) => Display::fmt(field, f),
         }
     }
 }

--- a/src/parsetree/mod.rs
+++ b/src/parsetree/mod.rs
@@ -60,9 +60,10 @@ pub use identifier::VelosiParseTreeIdentifier;
 pub use import::VelosiParseTreeImport;
 pub use interface::{
     VelosiParseTreeInterface, VelosiParseTreeInterfaceAction, VelosiParseTreeInterfaceActions,
-    VelosiParseTreeInterfaceField, VelosiParseTreeInterfaceFieldMemory,
-    VelosiParseTreeInterfaceFieldMmio, VelosiParseTreeInterfaceFieldNode,
-    VelosiParseTreeInterfaceFieldRegister, VelosiParseTreeInterfaceLayout,
+    VelosiParseTreeInterfaceField, VelosiParseTreeInterfaceFieldInstruction,
+    VelosiParseTreeInterfaceFieldMemory, VelosiParseTreeInterfaceFieldMmio,
+    VelosiParseTreeInterfaceFieldNode, VelosiParseTreeInterfaceFieldRegister,
+    VelosiParseTreeInterfaceLayout,
 };
 pub use map::{
     VelosiParseTreeMap, VelosiParseTreeMapElement, VelosiParseTreeMapExplicit,


### PR DESCRIPTION
This brings in a new keyword `instr` that allows the definition of special instructions in the interface. Instead of reading/writing a a register or memory location, this just executes the corresponding actions.  There are a few design points that may be tackled later.  how about immediates and arguments to the instruction. 